### PR TITLE
Error handling

### DIFF
--- a/app/api/login.go
+++ b/app/api/login.go
@@ -21,7 +21,7 @@ func APILoginHandler(w http.ResponseWriter, r *http.Request) {
 	token, err := auth("hypertube-auth", params.Username, params.Password, "default")
 	if err != nil {
 		fmt.Printf("error: %s\n", err)
-		ghttp.Adapt(pages.LoginHandler)(w, r)
+		ghttp.Adapt(pages.InternalErrorHandler)(w, r)
 		return
 	}
 

--- a/app/api/login.go
+++ b/app/api/login.go
@@ -20,8 +20,7 @@ func APILoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	token, err := auth("hypertube-auth", params.Username, params.Password, "default")
 	if err != nil {
-		fmt.Printf("error: %s\n", err)
-		ghttp.Adapt(pages.InternalErrorHandler)(w, r)
+		apiError(w, r, pages.Login, err.Error())
 		return
 	}
 

--- a/app/api/signin.go
+++ b/app/api/signin.go
@@ -84,7 +84,7 @@ func APISigninHandler(w http.ResponseWriter, r *http.Request) {
 
 	token, err := adminAuthorization()
 	if err != nil {
-		fmt.Printf("Failed to get authorization: %s\n", err.Error())
+		ghttp.Adapt(pages.InternalErrorHandler)(w, r)
 		return
 	}
 

--- a/app/api/signin.go
+++ b/app/api/signin.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -68,13 +69,13 @@ func createUser(params SigninParams, token string) error {
 		return nil
 	}
 
-	var data map[string]interface{}
+	var data map[string]string
 	err = json.Unmarshal(body, &data)
 	if err != nil {
 		return fmt.Errorf("Error parsing response %s", err.Error())
 	}
 
-	return fmt.Errorf("Error registering: %s", data["errorMessage"])
+	return errors.New(data["errorMessage"])
 }
 
 func APISigninHandler(w http.ResponseWriter, r *http.Request) {
@@ -89,15 +90,13 @@ func APISigninHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if params.Password != params.PasswordCheck {
-		fmt.Printf("Error: Password doesn't match\n")
-		ghttp.Adapt(pages.SigninHandler)(w, r)
+		apiError(w, r, pages.Signin, "Password doesn't match")
 		return
 	}
 
 	err = createUser(params, token)
 	if err != nil {
-		fmt.Printf("Failed to create user: %s\n", err.Error())
-		ghttp.Adapt(pages.SigninHandler)(w, r)
+		apiError(w, r, pages.Signin, err.Error())
 		return
 	}
 

--- a/app/components/internal_error.go
+++ b/app/components/internal_error.go
@@ -1,0 +1,12 @@
+package components
+
+import (
+	. "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+)
+
+func InternalError() Node {
+	return Center(
+		P(Class("title"), Text("Internal Server Error")),
+	)
+}

--- a/app/components/login.go
+++ b/app/components/login.go
@@ -15,7 +15,7 @@ func Center(content ...Node) Node {
 		Div(children...))
 }
 
-func Login() Node {
+func Login(error string) Node {
 	return Form(Method("Post"), Action("/login"),
 		Center(
 			P(Class("title"), Text("Log in to Hypertube")),
@@ -26,6 +26,10 @@ func Login() Node {
 			Input(Class("input password"),
 				Placeholder("Password..."),
 				Name("password")),
+
+			If(error != "",
+				P(Class("has-text-danger"), Text(error)),
+			),
 			Button(Class("button"),
 				Text("Log in"),
 			),

--- a/app/components/signin.go
+++ b/app/components/signin.go
@@ -5,7 +5,7 @@ import (
 	. "maragu.dev/gomponents/html"
 )
 
-func Signin() Node {
+func Signin(error string) Node {
 	return Form(Method("Post"), Action("/signin"),
 		Center(
 			P(Class("title"), Text("Sign in to Hypertube")),
@@ -38,6 +38,10 @@ func Signin() Node {
 				Type("password"),
 				Placeholder("Confirm Password..."),
 				Name("passwordCheck")),
+
+			If(error != "",
+				P(Class("has-text-danger"), Text(error)),
+			),
 			Button(Class("button"),
 				Text("Sign in"),
 			),

--- a/app/pages/handlers.go
+++ b/app/pages/handlers.go
@@ -11,11 +11,11 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
 }
 
 func LoginHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
-	return Login(), nil
+	return Login(""), nil
 }
 
 func SigninHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
-	return Signin(), nil
+	return Signin(""), nil
 }
 
 func InternalErrorHandler(w http.ResponseWriter, r *http.Request) (Node, error) {

--- a/app/pages/handlers.go
+++ b/app/pages/handlers.go
@@ -17,3 +17,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
 func SigninHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
 	return Signin(), nil
 }
+
+func InternalErrorHandler(w http.ResponseWriter, r *http.Request) (Node, error) {
+	return InternalError(), nil
+}

--- a/app/pages/internal_error.go
+++ b/app/pages/internal_error.go
@@ -1,0 +1,17 @@
+package pages
+
+import (
+	"github.com/demostanis/hypertube/components"
+
+	. "maragu.dev/gomponents"
+)
+
+func InternalError() Node {
+	return components.Page(
+		components.Navbar(),
+		components.Contents(
+			components.InternalError(),
+		),
+		components.Foot(),
+	)
+}

--- a/app/pages/login.go
+++ b/app/pages/login.go
@@ -6,11 +6,11 @@ import (
 	. "maragu.dev/gomponents"
 )
 
-func Login() Node {
+func Login(error string) Node {
 	return components.Page(
 		components.Navbar(),
 		components.Contents(
-			components.Login(),
+			components.Login(error),
 		),
 		components.Foot(),
 	)

--- a/app/pages/signin.go
+++ b/app/pages/signin.go
@@ -6,11 +6,11 @@ import (
 	. "maragu.dev/gomponents"
 )
 
-func Signin() Node {
+func Signin(err string) Node {
 	return components.Page(
 		components.Navbar(),
 		components.Contents(
-			components.Signin(),
+			components.Signin(err),
 		),
 		components.Foot(),
 	)


### PR DESCRIPTION
- internal server error page, i only use it when i cant get the admin token so it theoratically never happens but it could be useful
- api can now pass errors down to the pages thanks to the apiError function: this function can call any page that can take a string representing an error and send it to the client with a personnalized message
- theses modifications allowed me remove/modify some useless logs which are now visible directly on the website